### PR TITLE
Github Actions를 활용한 CI/CD 파이프라인 구축

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,15 +38,27 @@ jobs:
           username: ubuntu
           key: ${{ secrets.AWS_SSH_PK }}
           script: |
+            echo "🚀 EC2에 배포 시작"
+            
             # 1. 레포지토리 pull
             cd BE-main
             git pull origin main
+            
+            RAW_TAG="${{ github.event.workflow_run.head_branch }}"
+            IMAGE_TAG="${RAW_TAG#v}"
+            echo "📦 전달받은 Git 태그: $RAW_TAG → 이미지 태그: $IMAGE_TAG"
             
             # 2. .env.prod 존재하지 않으면 에러
             if [ ! -f .env.prod ]; then
               echo "❌ .env.prod 파일이 없습니다. 수동으로 업로드해주세요."
               exit 1
             fi
+            
+            echo "📝 .env.prod IMAGE_TAG 업데이트"
+            # 기존 IMAGE_TAG 라인이 있으면 덮어쓰기, 없으면 추가
+            grep -q '^IMAGE_TAG=' .env.prod && \
+              sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$IMAGE_TAG/" .env.prod || \
+              echo "IMAGE_TAG=$IMAGE_TAG" >> .env.prod
 
             # 3. 배포 스크립트 실행
             chmod +x scripts/run-docker-prod.sh

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,12 +35,22 @@ jobs:
         with:
           host: ${{ secrets.AWS_INSTANCE_HOST }}
           port: ${{ secrets.AWS_SSH_PORT }}
-          username: oomia
+          username: ubuntu
           key: ${{ secrets.AWS_SSH_PK }}
           script: |
-            cd inssider-spring-template
-            docker compose pull
-            docker compose up -d -y
+            # 1. 레포지토리 pull
+            cd BE-main
+            git pull origin main
+            
+            # 2. .env.prod 존재하지 않으면 에러
+            if [ ! -f .env.prod ]; then
+              echo "❌ .env.prod 파일이 없습니다. 수동으로 업로드해주세요."
+              exit 1
+            fi
+
+            # 3. 배포 스크립트 실행
+            chmod +x scripts/run-docker-prod.sh
+            ./scripts/run-docker-prod.sh
 
       - name: Close SSH port after deploy
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,8 +23,8 @@ jobs:
             ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.DOCKER_IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+#            type=semver,pattern={{major}}.{{minor}}
+#            type=semver,pattern={{major}}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3.4.0

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - "v*.*.*"
+    branches:
+      - main
 
 jobs:
   docker:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,12 +12,15 @@ jobs:
     env:
       DOCKER_BUILD_RECORD_RETENTION_DAYS: 1
     steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5.7.0
         with:
           images: |
-            ${{ vars.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
+            ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.DOCKER_IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,3 +37,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags || 'latest' }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -13,7 +13,7 @@ services:
       - app
 
   app:
-    image: jidak/inssider-be-main:1.0.0
+    image: jidak/inssider-be-main:${IMAGE_TAG}
     restart: "on-failure"
 #    env_file: [.env.prod]
     environment:


### PR DESCRIPTION
## Description

기존에 있던 `deploy.yml`, `publish.yml`을 일부 수정했습니다.

**✅ 전체 CI/CD 파이프라인 실행 흐름 구성**
1. 🏷️ 로컬에서 git 태그 생성 & 푸시 (main 브랜치)
2. 📤 [CI 단계] GitHub Actions – `publish.yml` 실행
  2.1. Docker 이미지 빌드
  2.2 Docker Hub에 이미지 push
3. 📥 [CD 단계] GitHub Actions – `deploy.yml` 실행
  3.1. EC2에 SSH 접속
  3.2. git 태그에서 현재 이미지 태그 추출 후 `.env.prod` 업데이트
  3.3. 배포 스크립트 실행

## TO-BE

6월 4일 배포 테스트 예정

## ETC.

지금 구성은 main 브랜치에 push가 일어났을 때 파이프라인이 동작하는 것이 아니라
main 브랜치에서 다음의 과정이 수행되었을 때 파이프라인이 동작하는 방식입니다.
```bash
git tag v0.0.1
git push origin v0.0.1
```