### PR TITLE
Fix: 프로젝트 버전 관리

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
+      - name: Run spotlessCheck
+        run: ./gradlew spotlessCheck
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5.7.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,8 +22,10 @@ fun String.runCommand(): String? =
         .bufferedReader()
         .readText()
 
+val versionTag = gitTag?.takeIf { it.startsWith("v") }?.removePrefix("v") ?: "0.0.10-SNAPSHOT"
+
 group = "com.inssider"
-version = gitTag?.removePrefix("v") ?: "0.0.1-SNAPSHOT"
+version = versionTag
 
 springBoot {
     buildInfo()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,22 +5,25 @@ plugins {
     id("com.diffplug.spotless") version "7.0.4"
 }
 
-val envFile = file(".env.prod")
-val envProps = mutableMapOf<String, String>()
+val gitTag: String? =
+    try {
+        "git describe --tags".runCommand()?.trim()
+    } catch (e: Exception) {
+        null
+    }
 
-if (envFile.exists()) {
-    envFile.readLines()
-        .filter { it.contains("=") && !it.trim().startsWith("#") }
-        .forEach {
-            val (key, value) = it.split("=", limit = 2)
-            envProps[key.trim()] = value.trim()
-        }
-}
-
-val imageTagVersion = envProps["IMAGE_TAG"] ?: "0.0.10-SNAPSHOT"
+// git 명령어 실행 함수
+fun String.runCommand(): String? =
+    ProcessBuilder(*split(" ").toTypedArray())
+        .directory(rootDir)
+        .redirectErrorStream(true)
+        .start()
+        .inputStream
+        .bufferedReader()
+        .readText()
 
 group = "com.inssider"
-version = imageTagVersion
+version = gitTag?.removePrefix("v") ?: "0.0.1-SNAPSHOT"
 
 springBoot {
     buildInfo()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,22 @@ plugins {
     id("com.diffplug.spotless") version "7.0.4"
 }
 
+val envFile = file(".env.prod")
+val envProps = mutableMapOf<String, String>()
+
+if (envFile.exists()) {
+    envFile.readLines()
+        .filter { it.contains("=") && !it.trim().startsWith("#") }
+        .forEach {
+            val (key, value) = it.split("=", limit = 2)
+            envProps[key.trim()] = value.trim()
+        }
+}
+
+val imageTagVersion = envProps["IMAGE_TAG"] ?: "0.0.10-SNAPSHOT"
+
 group = "com.inssider"
-version = "0.0.10-SNAPSHOT"
+version = imageTagVersion
 
 springBoot {
     buildInfo()

--- a/src/main/java/com/inssider/api/common/config/SwaggerConfig.java
+++ b/src/main/java/com/inssider/api/common/config/SwaggerConfig.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -24,6 +25,9 @@ import org.springframework.web.method.HandlerMethod;
 
 @Configuration
 class SwaggerConfig {
+
+  @Value("${build.version:unknown}")
+  private String buildVersion;
 
   @Bean
   @Primary
@@ -39,7 +43,7 @@ class SwaggerConfig {
         .info(
             new Info()
                 .title("Inssider API")
-                .version("0.0.10-SNAPSHOT")
+                .version(buildVersion)
                 .description("Inssider API Documentation"))
         .components(components());
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,16 @@
 # https://docs.spring.io/spring-boot/appendix/application-properties
 server.port: ${APP_PORT}
 
+management:
+  info:
+    build:
+      enabled: true
+
 spring:
   application:
     name: inssider-main
+  config:
+    import: optional:classpath:META-INF/build-info.properties
   datasource:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}


### PR DESCRIPTION
- CI/CD에서 spotlessCheck 수행 -> 포맷이 어긋나면 빌드 실패 처리
- `build.gradle.kts`에 현재 git tag와 version을 일치시키는 작업 추가