### PR TITLE
Refactor/add auth to content api

### DIFF
--- a/src/main/java/com/inssider/api/common/CommonControllerAdvice.java
+++ b/src/main/java/com/inssider/api/common/CommonControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.inssider.api.common;
 
+import org.springframework.security.access.AccessDeniedException;
 import java.util.NoSuchElementException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -47,6 +48,16 @@ class CommonControllerAdvice {
     ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.CONFLICT);
     problemDetail.setType(Util.buildAbsoluteUri("/error/conflict"));
     problemDetail.setTitle("Conflict");
+    problemDetail.setDetail(ex.getMessage());
+    return problemDetail;
+  }
+
+  @ExceptionHandler(AccessDeniedException.class)
+  @ResponseStatus(HttpStatus.FORBIDDEN)
+  public ProblemDetail accessDeniedHandler(AccessDeniedException ex) {
+    ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.FORBIDDEN);
+    problemDetail.setType(Util.buildAbsoluteUri("/error/access-denied"));
+    problemDetail.setTitle("Access Denied");
     problemDetail.setDetail(ex.getMessage());
     return problemDetail;
   }

--- a/src/main/java/com/inssider/api/common/service/VerifyService.java
+++ b/src/main/java/com/inssider/api/common/service/VerifyService.java
@@ -1,0 +1,7 @@
+package com.inssider.api.common.service;
+
+public interface VerifyService {
+    default boolean validateId(Long ownerId, Long reqId){
+        return ownerId.equals(reqId);
+    }
+}

--- a/src/main/java/com/inssider/api/domains/comment/controller/CommentController.java
+++ b/src/main/java/com/inssider/api/domains/comment/controller/CommentController.java
@@ -5,6 +5,8 @@ import com.inssider.api.domains.account.Account;
 import com.inssider.api.domains.comment.dto.*;
 import com.inssider.api.domains.comment.service.CommentService;
 import jakarta.validation.Valid;
+
+import java.nio.file.AccessDeniedException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -38,8 +40,8 @@ public class CommentController {
 
   @PatchMapping("/{commentId}")
   ResponseEntity<BaseResponse.ResponseWrapper<CommentUpdateResponseDTO>> update(
-      @PathVariable Long commentId, @RequestBody CommentUpdateRequestDTO reqBody) {
-    CommentUpdateResponseDTO data = commentService.update(commentId, reqBody);
+          @AuthenticationPrincipal Account reqAccount, @PathVariable Long commentId, @RequestBody CommentUpdateRequestDTO reqBody) throws AccessDeniedException {
+    CommentUpdateResponseDTO data = commentService.update(reqAccount, commentId, reqBody);
     return BaseResponse.of(200, data);
   }
 

--- a/src/main/java/com/inssider/api/domains/comment/controller/CommentController.java
+++ b/src/main/java/com/inssider/api/domains/comment/controller/CommentController.java
@@ -6,7 +6,6 @@ import com.inssider.api.domains.comment.dto.*;
 import com.inssider.api.domains.comment.service.CommentService;
 import jakarta.validation.Valid;
 
-import java.nio.file.AccessDeniedException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -40,7 +39,7 @@ public class CommentController {
 
   @PatchMapping("/{commentId}")
   ResponseEntity<BaseResponse.ResponseWrapper<CommentUpdateResponseDTO>> update(
-          @AuthenticationPrincipal Account reqAccount, @PathVariable Long commentId, @RequestBody CommentUpdateRequestDTO reqBody) throws AccessDeniedException {
+          @AuthenticationPrincipal Account reqAccount, @PathVariable Long commentId, @RequestBody CommentUpdateRequestDTO reqBody){
     CommentUpdateResponseDTO data = commentService.update(reqAccount, commentId, reqBody);
     return BaseResponse.of(200, data);
   }

--- a/src/main/java/com/inssider/api/domains/comment/controller/CommentController.java
+++ b/src/main/java/com/inssider/api/domains/comment/controller/CommentController.java
@@ -32,8 +32,8 @@ public class CommentController {
 
   @PatchMapping("/delete/{commentId}")
   ResponseEntity<BaseResponse.ResponseWrapper<CommentDeleteResponseDTO>> delete(
-      @PathVariable Long commentId) {
-    CommentDeleteResponseDTO data = commentService.delete(commentId);
+          @AuthenticationPrincipal Account reqAccount, @PathVariable Long commentId) {
+    CommentDeleteResponseDTO data = commentService.delete(reqAccount, commentId);
     return BaseResponse.of(200, data);
   }
 

--- a/src/main/java/com/inssider/api/domains/comment/controller/CommentController.java
+++ b/src/main/java/com/inssider/api/domains/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.inssider.api.domains.comment.controller;
 
 import com.inssider.api.common.response.BaseResponse;
+import com.inssider.api.domains.account.Account;
 import com.inssider.api.domains.comment.dto.*;
 import com.inssider.api.domains.comment.service.CommentService;
 import jakarta.validation.Valid;
@@ -8,6 +9,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Log4j2
@@ -20,8 +22,10 @@ public class CommentController {
 
   @PostMapping("/{memeId}")
   ResponseEntity<BaseResponse.ResponseWrapper<CommentCreateResponseDTO>> create(
-      @PathVariable Long memeId, @Valid @RequestBody CommentCreateRequestDTO reqBody) {
-    CommentCreateResponseDTO data = commentService.create(memeId, reqBody);
+      @AuthenticationPrincipal Account reqAccount,
+      @PathVariable Long memeId,
+      @Valid @RequestBody CommentCreateRequestDTO reqBody) {
+    CommentCreateResponseDTO data = commentService.create(reqAccount, memeId, reqBody);
     return BaseResponse.of(201, data);
   }
 

--- a/src/main/java/com/inssider/api/domains/comment/service/CommentService.java
+++ b/src/main/java/com/inssider/api/domains/comment/service/CommentService.java
@@ -55,8 +55,12 @@ public class CommentService implements VerifyService {
     return CommentMapper.toDTO(createdComment);
   }
 
-  public CommentDeleteResponseDTO delete(Long commentId) {
+  public CommentDeleteResponseDTO delete(Account reqAccount, Long commentId) {
     Comment currentComment = findById(commentId);
+
+    if(!validateId(currentComment.getAccount().getId(), reqAccount.getId())){
+      throw new AccessDeniedException("삭제 권한이 없습니다.");
+    }
 
     if (!currentComment.getChildComments().isEmpty())
       throw new IllegalStateException("하위 댓글이 존재하여 삭제가 불가능합니다.");

--- a/src/main/java/com/inssider/api/domains/comment/service/CommentService.java
+++ b/src/main/java/com/inssider/api/domains/comment/service/CommentService.java
@@ -97,4 +97,8 @@ public class CommentService implements VerifyService {
         .findById(commentId)
         .orElseThrow(() -> new NoSuchElementException("존재하지 않는 댓글입니다."));
   }
+
+  public boolean isComment(Long commentId) {
+    return commentRepository.existsById(commentId);
+  }
 }

--- a/src/main/java/com/inssider/api/domains/comment/service/CommentService.java
+++ b/src/main/java/com/inssider/api/domains/comment/service/CommentService.java
@@ -11,7 +11,7 @@ import com.inssider.api.domains.post.entity.Post;
 import com.inssider.api.domains.post.service.PostService;
 import jakarta.transaction.Transactional;
 
-import java.nio.file.AccessDeniedException;
+import org.springframework.security.access.AccessDeniedException;
 import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
@@ -76,7 +76,7 @@ public class CommentService implements VerifyService {
     throw new NoSuchElementException("존재하지 않는 콘텐츠입니다.");
   }
 
-  public CommentUpdateResponseDTO update(Account reqAccount, Long commentId, CommentUpdateRequestDTO reqBody) throws AccessDeniedException {
+  public CommentUpdateResponseDTO update(Account reqAccount, Long commentId, CommentUpdateRequestDTO reqBody){
     Comment currentComment = findById(commentId);
 
     if(!validateId(currentComment.getAccount().getId(), reqAccount.getId())){

--- a/src/main/java/com/inssider/api/domains/comment/service/CommentService.java
+++ b/src/main/java/com/inssider/api/domains/comment/service/CommentService.java
@@ -24,9 +24,11 @@ public class CommentService {
   // 인증 적용 후 삭제 예정
   private final AccountService accountService;
 
-  public CommentCreateResponseDTO create(Long memeId, CommentCreateRequestDTO requestDTO) {
-    // 인증 적용 후 삭제 예정
-    Account account = accountService.findById(2L).get();
+  public CommentCreateResponseDTO create(
+      Account reqAccount, Long memeId, CommentCreateRequestDTO requestDTO) {
+
+    Account account =
+        accountService.findById(reqAccount.getId()).orElseThrow(NoSuchElementException::new);
     Post post = postService.get(memeId);
 
     Comment parentComment = null;

--- a/src/main/java/com/inssider/api/domains/comment/service/CommentService.java
+++ b/src/main/java/com/inssider/api/domains/comment/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.inssider.api.domains.comment.service;
 
+import com.inssider.api.common.service.VerifyService;
 import com.inssider.api.domains.account.Account;
 import com.inssider.api.domains.account.AccountService;
 import com.inssider.api.domains.comment.dto.*;
@@ -9,6 +10,8 @@ import com.inssider.api.domains.comment.repository.CommentRepository;
 import com.inssider.api.domains.post.entity.Post;
 import com.inssider.api.domains.post.service.PostService;
 import jakarta.transaction.Transactional;
+
+import java.nio.file.AccessDeniedException;
 import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +20,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class CommentService {
+public class CommentService implements VerifyService {
 
   private final CommentRepository commentRepository;
   private final PostService postService;
@@ -73,11 +76,16 @@ public class CommentService {
     throw new NoSuchElementException("존재하지 않는 콘텐츠입니다.");
   }
 
-  public CommentUpdateResponseDTO update(Long commentId, CommentUpdateRequestDTO reqBody) {
-    Comment comment = findById(commentId);
-    comment.updateContent(reqBody.getContent());
+  public CommentUpdateResponseDTO update(Account reqAccount, Long commentId, CommentUpdateRequestDTO reqBody) throws AccessDeniedException {
+    Comment currentComment = findById(commentId);
+
+    if(!validateId(currentComment.getAccount().getId(), reqAccount.getId())){
+      throw new AccessDeniedException("수정 권한이 없습니다.");
+    }
+
+    currentComment.updateContent(reqBody.getContent());
     commentRepository.flush();
-    return CommentMapper.toUpdateDTO(comment);
+    return CommentMapper.toUpdateDTO(currentComment);
   }
 
   public Comment findById(Long commentId) {

--- a/src/main/java/com/inssider/api/domains/like/controller/LikeController.java
+++ b/src/main/java/com/inssider/api/domains/like/controller/LikeController.java
@@ -1,6 +1,7 @@
 package com.inssider.api.domains.like.controller;
 
 import com.inssider.api.common.response.BaseResponse;
+import com.inssider.api.domains.account.Account;
 import com.inssider.api.domains.like.dto.LikeRequestDTO;
 import com.inssider.api.domains.like.dto.LikeResponseDTO;
 import com.inssider.api.domains.like.service.LikeService;
@@ -8,6 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,8 +24,8 @@ public class LikeController {
 
   @PostMapping("{typeId}/like")
   ResponseEntity<BaseResponse.ResponseWrapper<LikeResponseDTO>> register(
-      @PathVariable Long typeId, @Valid @RequestBody LikeRequestDTO reqBody) {
-    LikeResponseDTO data = likeService.post(typeId, reqBody);
+          @AuthenticationPrincipal Account reqAccount, @PathVariable Long typeId, @Valid @RequestBody LikeRequestDTO reqBody) {
+    LikeResponseDTO data = likeService.post(reqAccount, typeId, reqBody);
     return BaseResponse.of(200, data);
   }
 }

--- a/src/main/java/com/inssider/api/domains/like/service/LikeService.java
+++ b/src/main/java/com/inssider/api/domains/like/service/LikeService.java
@@ -2,6 +2,7 @@ package com.inssider.api.domains.like.service;
 
 import com.inssider.api.domains.account.Account;
 import com.inssider.api.domains.account.AccountService;
+import com.inssider.api.domains.comment.service.CommentService;
 import com.inssider.api.domains.like.LikeTargetType;
 import com.inssider.api.domains.like.dto.LikeRequestDTO;
 import com.inssider.api.domains.like.dto.LikeResponseDTO;
@@ -21,15 +22,13 @@ public class LikeService {
 
   private final LikeRepository likeRepository;
   private final PostService postService;
-
-  // 인증 적용 후 삭제 예정
+  private final CommentService commentService;
   private final AccountService accountService;
 
-  public LikeResponseDTO post(Long targetId, LikeRequestDTO requestDTO) {
+  public LikeResponseDTO post(Account reqAccount, Long targetId, LikeRequestDTO requestDTO) {
     boolean liked = true;
-    // 인증 적용 후 삭제 예정
-    Account account = accountService.findById(1L).get();
-
+    Account account = accountService.findById(reqAccount.getId())
+            .orElseThrow(() -> new IllegalStateException("인증 절차 완료 후 접근해주세요."));
     validateTarget(targetId, requestDTO.getTargetType());
     boolean currentLiked =
         likeRepository.existsByAccountIdAndTargetTypeAndTargetId(
@@ -39,7 +38,7 @@ public class LikeService {
 
     if (currentLiked) {
       likeRepository.deleteByAccountIdAndTargetTypeAndTargetId(
-          account.getId(), requestDTO.getTargetType(), targetId);
+              account.getId(), requestDTO.getTargetType(), targetId);
       liked = false;
       return LikeMapper.toUnLikedDTO(
           requestDTO.getTargetType().name(), targetId, liked, totalLikeCount - 1);
@@ -63,7 +62,10 @@ public class LikeService {
           throw new EntityNotFoundException("존재하지 않는 콘텐츠입니다.");
         }
         break;
-      case COMMENT: // 추가 예정
+      case COMMENT:
+        if (!commentService.isComment(targetId)) {
+          throw new EntityNotFoundException("존재하지 않는 댓글입니다.");
+        }
         break;
     }
   }

--- a/src/main/java/com/inssider/api/domains/post/controller/PostController.java
+++ b/src/main/java/com/inssider/api/domains/post/controller/PostController.java
@@ -40,8 +40,8 @@ public class PostController {
 
   @PatchMapping("/delete/{memeId}")
   ResponseEntity<BaseResponse.ResponseWrapper<PostDeleteResponseDTO>> delete(
-      @PathVariable Long memeId) {
-    PostDeleteResponseDTO data = postService.delete(memeId);
+          @AuthenticationPrincipal Account reqAccount, @PathVariable Long memeId) {
+    PostDeleteResponseDTO data = postService.delete(reqAccount, memeId);
     return BaseResponse.of(200, data);
   }
 

--- a/src/main/java/com/inssider/api/domains/post/controller/PostController.java
+++ b/src/main/java/com/inssider/api/domains/post/controller/PostController.java
@@ -6,7 +6,6 @@ import com.inssider.api.domains.post.dto.*;
 import com.inssider.api.domains.post.service.PostService;
 import jakarta.validation.Valid;
 
-import java.nio.file.AccessDeniedException;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +33,7 @@ public class PostController {
 
   @PatchMapping("/{memeId}")
   ResponseEntity<BaseResponse.ResponseWrapper<PostUpdateResponseDTO>> update(
-      @AuthenticationPrincipal Account reqAccount, @PathVariable Long memeId, @RequestBody PostUpdateRequestDTO reqBody) throws AccessDeniedException {
+      @AuthenticationPrincipal Account reqAccount, @PathVariable Long memeId, @RequestBody PostUpdateRequestDTO reqBody){
     PostUpdateResponseDTO data = postService.update(reqAccount, memeId, reqBody);
     return BaseResponse.of(200, data);
   }

--- a/src/main/java/com/inssider/api/domains/post/controller/PostController.java
+++ b/src/main/java/com/inssider/api/domains/post/controller/PostController.java
@@ -24,7 +24,8 @@ public class PostController {
 
   @PostMapping
   ResponseEntity<BaseResponse.ResponseWrapper<PostResponseDTO>> register(
-          @AuthenticationPrincipal Account reqAccount, @Valid @RequestBody PostCreateRequestDTO reqBody) {
+      @AuthenticationPrincipal Account reqAccount,
+      @Valid @RequestBody PostCreateRequestDTO reqBody) {
     PostResponseDTO data = postService.create(reqAccount, reqBody);
     return BaseResponse.of(201, data);
   }

--- a/src/main/java/com/inssider/api/domains/post/controller/PostController.java
+++ b/src/main/java/com/inssider/api/domains/post/controller/PostController.java
@@ -5,6 +5,8 @@ import com.inssider.api.domains.account.Account;
 import com.inssider.api.domains.post.dto.*;
 import com.inssider.api.domains.post.service.PostService;
 import jakarta.validation.Valid;
+
+import java.nio.file.AccessDeniedException;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -32,8 +34,8 @@ public class PostController {
 
   @PatchMapping("/{memeId}")
   ResponseEntity<BaseResponse.ResponseWrapper<PostUpdateResponseDTO>> update(
-      @PathVariable Long memeId, @RequestBody PostUpdateRequestDTO reqBody) {
-    PostUpdateResponseDTO data = postService.update(memeId, reqBody);
+      @AuthenticationPrincipal Account reqAccount, @PathVariable Long memeId, @RequestBody PostUpdateRequestDTO reqBody) throws AccessDeniedException {
+    PostUpdateResponseDTO data = postService.update(reqAccount, memeId, reqBody);
     return BaseResponse.of(200, data);
   }
 

--- a/src/main/java/com/inssider/api/domains/post/controller/PostController.java
+++ b/src/main/java/com/inssider/api/domains/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.inssider.api.domains.post.controller;
 
 import com.inssider.api.common.response.BaseResponse;
+import com.inssider.api.domains.account.Account;
 import com.inssider.api.domains.post.dto.*;
 import com.inssider.api.domains.post.service.PostService;
 import jakarta.validation.Valid;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Log4j2
@@ -22,8 +24,8 @@ public class PostController {
 
   @PostMapping
   ResponseEntity<BaseResponse.ResponseWrapper<PostResponseDTO>> register(
-      @Valid @RequestBody PostCreateRequestDTO reqBody) {
-    PostResponseDTO data = postService.create(reqBody);
+          @AuthenticationPrincipal Account reqAccount, @Valid @RequestBody PostCreateRequestDTO reqBody) {
+    PostResponseDTO data = postService.create(reqAccount, reqBody);
     return BaseResponse.of(201, data);
   }
 

--- a/src/main/java/com/inssider/api/domains/post/service/PostService.java
+++ b/src/main/java/com/inssider/api/domains/post/service/PostService.java
@@ -30,7 +30,8 @@ public class PostService {
   private final AccountService accountService;
 
   public PostResponseDTO create(Account reqAccount, PostCreateRequestDTO reqBody) {
-    Account account = accountService.findById(reqAccount.getId()).orElseThrow(NoSuchElementException::new);
+    Account account =
+        accountService.findById(reqAccount.getId()).orElseThrow(NoSuchElementException::new);
     Category category =
         categoryService
             .getCategory(reqBody.getCategoryType())

--- a/src/main/java/com/inssider/api/domains/post/service/PostService.java
+++ b/src/main/java/com/inssider/api/domains/post/service/PostService.java
@@ -1,5 +1,6 @@
 package com.inssider.api.domains.post.service;
 
+import com.inssider.api.common.service.VerifyService;
 import com.inssider.api.domains.account.Account;
 import com.inssider.api.domains.account.AccountService;
 import com.inssider.api.domains.category.entity.Category;
@@ -11,17 +12,20 @@ import com.inssider.api.domains.post.repository.PostRepository;
 import com.inssider.api.domains.tag.entity.Tag;
 import com.inssider.api.domains.tag.service.TagService;
 import jakarta.transaction.Transactional;
+
+import java.nio.file.AccessDeniedException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class PostService {
+public class PostService implements VerifyService {
 
   private final PostRepository postRepository;
   private final CategoryService categoryService;
@@ -47,11 +51,16 @@ public class PostService {
     return PostMapper.postToDTO(post);
   }
 
-  public PostUpdateResponseDTO update(Long memeId, PostUpdateRequestDTO reqBody) {
+  public PostUpdateResponseDTO update(Account reqAccount, Long memeId, PostUpdateRequestDTO reqBody) throws AccessDeniedException {
+
     Post currentPost =
         postRepository
             .findByIdWithTag(memeId)
-            .orElseThrow(() -> new IllegalArgumentException("게시글 오류 발생"));
+            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 게시물입니다."));
+
+    if(!validateId(currentPost.getAccount().getId(), reqAccount.getId())){
+      throw new AccessDeniedException("수정 권한이 없습니다.");
+    }
 
     if (reqBody.hasTitle()) {
       currentPost.updateTitle(reqBody.getTitle());

--- a/src/main/java/com/inssider/api/domains/post/service/PostService.java
+++ b/src/main/java/com/inssider/api/domains/post/service/PostService.java
@@ -27,12 +27,10 @@ public class PostService {
   private final CategoryService categoryService;
   private final TagService tagService;
 
-  // 인증 적용 후 삭제 예정
   private final AccountService accountService;
 
-  public PostResponseDTO create(PostCreateRequestDTO reqBody) {
-    // 인증 적용 후 삭제 예정
-    Account account = accountService.findById(1L).get();
+  public PostResponseDTO create(Account reqAccount, PostCreateRequestDTO reqBody) {
+    Account account = accountService.findById(reqAccount.getId()).orElseThrow(NoSuchElementException::new);
     Category category =
         categoryService
             .getCategory(reqBody.getCategoryType())

--- a/src/main/java/com/inssider/api/domains/post/service/PostService.java
+++ b/src/main/java/com/inssider/api/domains/post/service/PostService.java
@@ -56,7 +56,7 @@ public class PostService implements VerifyService {
     Post currentPost =
         postRepository
             .findByIdWithTag(memeId)
-            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 게시물입니다."));
+            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 콘텐츠입니다."));
 
     if(!validateId(currentPost.getAccount().getId(), reqAccount.getId())){
       throw new AccessDeniedException("수정 권한이 없습니다.");
@@ -96,11 +96,16 @@ public class PostService implements VerifyService {
     return PostMapper.postToUpdateDTO(updatedPost);
   }
 
-  public PostDeleteResponseDTO delete(Long memeId) {
+  public PostDeleteResponseDTO delete(Account reqAccount, Long memeId) {
     Post currentPost =
         postRepository
             .findByIdWithTag(memeId)
-            .orElseThrow(() -> new IllegalArgumentException("게시글 오류 발생"));
+            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 콘텐츠입니다."));
+
+    if(!validateId(currentPost.getAccount().getId(), reqAccount.getId())){
+      throw new AccessDeniedException("삭제 권한이 없습니다.");
+    }
+
     currentPost.updateIsDeleted();
     currentPost.updateDeletedAt();
     Post updatedPost = postRepository.save(currentPost);

--- a/src/main/java/com/inssider/api/domains/post/service/PostService.java
+++ b/src/main/java/com/inssider/api/domains/post/service/PostService.java
@@ -13,7 +13,7 @@ import com.inssider.api.domains.tag.entity.Tag;
 import com.inssider.api.domains.tag.service.TagService;
 import jakarta.transaction.Transactional;
 
-import java.nio.file.AccessDeniedException;
+import org.springframework.security.access.AccessDeniedException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -51,7 +51,7 @@ public class PostService implements VerifyService {
     return PostMapper.postToDTO(post);
   }
 
-  public PostUpdateResponseDTO update(Account reqAccount, Long memeId, PostUpdateRequestDTO reqBody) throws AccessDeniedException {
+  public PostUpdateResponseDTO update(Account reqAccount, Long memeId, PostUpdateRequestDTO reqBody){
 
     Post currentPost =
         postRepository


### PR DESCRIPTION
## 작업 내용
### auth 적용
post /api/posts (콘텐츠 작성)
post /api/:memeId/like (콘텐츠 좋아요)
patch /api/posts/:memeId (콘텐츠 수정)
patch /api/posts/delete/:memeId (콘텐츠 삭제)
post /api/comments/:memeId (댓글 작성)
patch/api/comments/:commentId (댓글 수정)
patch /api/comments/delete/:commentId (댓글 삭제)

## 현재 상황
현재 get /api/posts (공감밈 콘텐츠 보기, 좋아요 누른 콘텐츠 보기만 auth 적용) 기능은 적용하면서 오류가 발생해서 완성하지 못했습니다.
위 기능 제외하고, 밈 콘텐츠 부분은 모두 인증 적용됐습니다! 일단 현재 작업물까지 pr 날립니다~
